### PR TITLE
Fix wallet display synchronization and setup flow

### DIFF
--- a/docs/logs/20250523/0406-walletdisplay-instructions.md
+++ b/docs/logs/20250523/0406-walletdisplay-instructions.md
@@ -1,0 +1,118 @@
+Okay, I understand the issues. The wallet balance displayed in the "Wallet Pane" and the "Wallet HUD" (top-right display) are not staying synchronized, and you want the balance in both locations to refresh every 1 second.
+
+Here are the specific instructions for a coding agent to implement these changes:
+
+**Objective 1: Synchronize Wallet Balance Display**
+Ensure both the Wallet Pane and the Wallet HUD display the same balance value by using a unified React Query key.
+
+**Objective 2: Implement 1-Second Balance Refresh**
+Update the balance fetching logic to refresh every 1 second.
+
+---
+
+**Instructions for the Coding Agent:**
+
+**File 1: `src/components/wallet/WalletPane.tsx`**
+
+1.  **Locate the `useQuery` hook** responsible for fetching the wallet balance. It currently looks like this:
+    ```typescript
+    const {
+      data: balanceData,
+      isLoading: isLoadingBalance,
+      error: balanceError,
+      refetch: refetchBalance,
+    } = useQuery<BalanceInfo, Error>({
+      queryKey: ["walletPaneBitcoinBalance"], // <--- Current key
+      queryFn: async () => { /* ... */ },
+      refetchInterval: 60000, // <--- Current interval
+    });
+    ```
+
+2.  **Modify the `queryKey`**:
+    *   Change the `queryKey` from `["walletPaneBitcoinBalance"]` to `["walletBalance"]`.
+    This standardized key will ensure React Query treats balance data from different components as the same resource.
+
+3.  **Modify the `refetchInterval`**:
+    *   Change `refetchInterval: 60000` to `refetchInterval: 1000`.
+
+4.  **Add a performance warning comment**:
+    *   Immediately above or below the `refetchInterval: 1000` line, add the following comment:
+      ```typescript
+      // TODO: Aggressive 1s balance refresh. Monitor performance and API rate limits. Consider websockets or longer intervals for production.
+      ```
+
+5.  The modified `useQuery` options should look like this:
+    ```typescript
+    const {
+      data: balanceData,
+      isLoading: isLoadingBalance,
+      error: balanceError,
+      refetch: refetchBalance,
+    } = useQuery<BalanceInfo, Error>({
+      queryKey: ["walletBalance"], // <--- MODIFIED
+      queryFn: async () => { /* ... */ },
+      // TODO: Aggressive 1s balance refresh. Monitor performance and API rate limits. Consider websockets or longer intervals for production.
+      refetchInterval: 1000, // <--- MODIFIED
+    });
+    ```
+
+**File 2: `src/components/hud/BitcoinBalanceDisplay.tsx`**
+
+1.  **Locate the `useQuery` hook** responsible for fetching the wallet balance. It currently looks like this (based on its functionality):
+    ```typescript
+    const {
+      data: balanceData,
+      isLoading,
+      error,
+      refetch,
+      isFetching,
+    } = useQuery<BalanceInfo, Error>({
+      queryKey: ["bitcoinBalance"], // <--- Current key
+      queryFn: async () => { /* ... */ },
+      refetchInterval: 30000, // <--- Current interval
+      refetchIntervalInBackground: true,
+    });
+    ```
+
+2.  **Modify the `queryKey`**:
+    *   Change the `queryKey` from `["bitcoinBalance"]` to `["walletBalance"]`.
+    This ensures it uses the same React Query cache entry as the `WalletPane.tsx`.
+
+3.  **Modify the `refetchInterval`**:
+    *   Change `refetchInterval: 30000` to `refetchInterval: 1000`.
+
+4.  **Add a performance warning comment**:
+    *   Immediately above or below the `refetchInterval: 1000` line, add the following comment:
+      ```typescript
+      // TODO: Aggressive 1s balance refresh. Monitor performance and API rate limits. Consider websockets or longer intervals for production.
+      ```
+
+5.  The modified `useQuery` options should look like this:
+    ```typescript
+    const {
+      data: balanceData,
+      isLoading,
+      error,
+      refetch,
+      isFetching,
+    } = useQuery<BalanceInfo, Error>({
+      queryKey: ["walletBalance"], // <--- MODIFIED
+      queryFn: async () => { /* ... */ },
+      // TODO: Aggressive 1s balance refresh. Monitor performance and API rate limits. Consider websockets or longer intervals for production.
+      refetchInterval: 1000, // <--- MODIFIED
+      refetchIntervalInBackground: true,
+    });
+    ```
+
+---
+
+**Verification Steps (for human tester):**
+
+1.  After changes, run the application.
+2.  Open both the "Wallet Pane" (if it's a separate pane that can be opened/closed) and ensure the "Wallet HUD" (top-right display) is visible.
+3.  Observe the balance in both locations. They should now display the same value and update consistently every 1 second.
+4.  If one component triggers a manual refetch (e.g., via the refresh button in `BitcoinBalanceDisplay.tsx`), the other component should also reflect the updated data almost immediately due to the shared query key.
+5.  Monitor the application for any performance degradation or excessive network requests in the developer console's network tab. Check for any console warnings related to API rate limits if applicable to the Spark SDK.
+
+**Note on `SparkService` and Mnemonic Usage:**
+The existing architecture, particularly the use of `globalWalletConfig` and `reinitializeRuntime` in `src/services/runtime.ts` and `src/stores/walletStore.ts`, should ensure that the `SparkService` instance used by React Query is correctly configured with the user's mnemonic. These changes to query keys and refresh intervals should not interfere with that mechanism. The balance displayed will be from the currently active wallet instance.

--- a/docs/logs/20250523/0406-walletdisplay-log.md
+++ b/docs/logs/20250523/0406-walletdisplay-log.md
@@ -1,0 +1,45 @@
+# Wallet Display Synchronization Log - 0406
+
+## Overview
+Implementing wallet balance synchronization between Wallet Pane and Wallet HUD with 1-second refresh interval.
+
+## Issues to Fix
+1. Wallet balance not synchronized between Wallet Pane and HUD
+2. Balance should refresh every 1 second in both locations
+
+## Implementation Plan
+1. Update WalletPane.tsx to use unified query key and 1s refresh
+2. Update BitcoinBalanceDisplay.tsx to use same query key and 1s refresh
+3. Add performance warning comments
+4. Test synchronization
+
+## Progress
+
+### Step 1: Examining Current Implementation
+
+Found current implementations:
+- WalletPane.tsx: Using queryKey ["walletPaneBitcoinBalance"] with 60s refresh
+- BitcoinBalanceDisplay.tsx: Using queryKey ["bitcoinBalance"] with 30s refresh
+
+### Step 2: Updated WalletPane.tsx
+
+Changed:
+- queryKey from ["walletPaneBitcoinBalance"] to ["walletBalance"]
+- refetchInterval from 60000 to 1000 (1 second)
+- Added performance warning comment
+
+### Step 3: Updated BitcoinBalanceDisplay.tsx
+
+Changed:
+- queryKey from ["bitcoinBalance"] to ["walletBalance"]
+- refetchInterval from 30000 to 1000 (1 second)
+- Added performance warning comment
+
+## Summary
+
+Both components now:
+1. Use the same React Query key ["walletBalance"] for cache sharing
+2. Refresh balance every 1 second
+3. Include performance warning comments about aggressive refresh rate
+
+This ensures the balance displayed in the Wallet Pane and HUD are synchronized and update every second. When one component refetches, both will show the same data due to the shared query key.

--- a/docs/logs/20250523/0410-wallet-fixes-log.md
+++ b/docs/logs/20250523/0410-wallet-fixes-log.md
@@ -1,0 +1,43 @@
+# Wallet Display Fixes Log - 0410
+
+## Issues to Fix
+1. Top-right balance display doesn't clear when user logs out
+2. Wallet pane is showing automatically - should only open when user clicks hotbar or top-right display
+
+## Implementation Plan
+1. Make BitcoinBalanceDisplay check wallet initialization state
+2. Find where wallet pane is being opened automatically and remove it
+3. Ensure wallet pane only opens via explicit user action
+
+## Progress
+
+### Step 1: Examining BitcoinBalanceDisplay logout behavior
+
+Found that BitcoinBalanceDisplay doesn't check wallet initialization state before showing balance.
+
+### Step 2: Fixed BitcoinBalanceDisplay
+
+Added:
+1. Import useWalletStore
+2. Check walletIsInitialized state
+3. Show "No wallet" when not initialized
+4. Added enabled: walletIsInitialized to useQuery to prevent fetching when logged out
+
+### Step 3: Investigating Wallet Pane Auto-Show Issue
+
+Checked:
+- pane.ts initial state - only shows Sell Compute pane ✓
+- merge function - ignores persisted state and forces clean start ✓
+- PaneManager - only renders panes in store ✓
+- Hotbar - only opens wallet on click ✓
+
+The wallet pane should NOT be showing automatically. The store is configured to only show Sell Compute pane on startup.
+
+## Summary
+
+1. Fixed top-right balance to show "No wallet" when logged out
+2. Wallet pane is already configured to NOT show automatically - it only opens when:
+   - User clicks wallet button in hotbar
+   - User clicks top-right balance display
+
+If wallet pane is still showing automatically, it might be a browser cache issue. The store's merge function explicitly ignores persisted state and only shows Sell Compute pane.

--- a/docs/logs/20250523/0414-storage-reset-log.md
+++ b/docs/logs/20250523/0414-storage-reset-log.md
@@ -1,0 +1,24 @@
+# Storage Reset Log - 0414
+
+## Issue
+Wallet setup pane (non-dismissable) is showing on page refresh despite the merge function that should only show Sell Compute pane.
+
+## Solution
+Need to change the storage key to force a clean slate for all users.
+
+## Implementation
+
+### Step 1: Changed Storage Key
+Changed pane storage key from "commander-pane-storage-v2" to "commander-pane-storage-v3" to force a clean slate.
+
+### Step 2: Found Root Cause
+App.tsx was calling `checkWalletSetupNeeded()` on startup which automatically opens wallet setup pane if wallet is not initialized.
+
+### Step 3: Disabled Automatic Wallet Setup
+Commented out the useEffect that calls checkWalletSetupNeeded(). Users should explicitly choose to set up their wallet, not be forced into it.
+
+## Result
+- Storage key changed to v3 (clears all persisted panes)
+- Automatic wallet setup disabled
+- Only Sell Compute pane will show on startup
+- Users can set up wallet when they're ready via wallet button

--- a/docs/logs/20250523/0418-wallet-setup-fix-log.md
+++ b/docs/logs/20250523/0418-wallet-setup-fix-log.md
@@ -1,0 +1,33 @@
+# Wallet Setup Fix Log - 0418
+
+## Issues
+1. Clicking "No wallet" shows balance from test wallet (48 sats)
+2. Should open wallet setup screen instead
+3. Test wallet data is persisting somehow
+
+## Plan
+1. Fix BitcoinBalanceDisplay to open wallet setup when no wallet
+2. Clear any persisted wallet data
+3. Ensure SparkService doesn't use test wallet when logged out
+
+## Implementation
+
+### Step 1: Fixed BitcoinBalanceDisplay Click Handler
+- Added openWalletSetupPane to imports
+- Changed click handler to:
+  - Open wallet pane if wallet is initialized
+  - Open wallet setup pane if no wallet
+
+### Step 2: Reset Wallet Store Persistence
+- Changed wallet store key from "commander-wallet-store" to "commander-wallet-store-v2"
+- This clears any persisted test wallet data
+
+### Step 3: Clear React Query Cache
+- Added useEffect to clear balance cache when wallet not initialized
+- Uses queryClient.invalidateQueries and removeQueries
+- Ensures no stale balance data shows when logged out
+
+## Result
+- Clicking "No wallet" now opens wallet setup screen
+- Test wallet balance (48 sats) is cleared
+- Fresh start for all users

--- a/docs/logs/20250523/0425-wallet-sync-fix-log.md
+++ b/docs/logs/20250523/0425-wallet-sync-fix-log.md
@@ -1,0 +1,14 @@
+# Wallet Sync Fix Log - 0425
+
+## Issue
+- Top-right shows "No wallet" correctly
+- But opening wallet pane from hotbar shows 48 sats
+- Two components are not properly synced despite using same query key
+
+## Root Cause
+Both components fetch balance independently. Need to ensure wallet pane also checks wallet initialization state.
+
+## Solution
+Make WalletPane check walletIsInitialized and show appropriate UI when no wallet exists.
+
+## Implementation

--- a/scripts/copyAllToClipboard.js
+++ b/scripts/copyAllToClipboard.js
@@ -24,6 +24,7 @@ const dirsToScan = ["docs", "src", "node_modules/@effect/ai-openai/dist/dts/"];
 const dirsToExclude = [
   // "src/components",
   "src/localization/",
+  "src/services/ai/providers",
   // "src/stores/panes/",
   "src/assets/fonts",
   "docs/logs/20250514",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -56,10 +56,10 @@ export default function App() {
     updateAppLanguage(i18n);
   }, [i18n]);
 
-  // Check wallet setup after the initial render and browser paint
-  useEffect(() => {
-    checkWalletSetupNeeded();
-  }, []);
+  // DISABLED: Automatic wallet setup - users should explicitly choose to set up wallet
+  // useEffect(() => {
+  //   checkWalletSetupNeeded();
+  // }, []);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/components/hud/BitcoinBalanceDisplay.tsx
+++ b/src/components/hud/BitcoinBalanceDisplay.tsx
@@ -19,7 +19,7 @@ const BitcoinBalanceDisplay: React.FC = () => {
     refetch,
     isFetching,
   } = useQuery<BalanceInfo, Error>({
-    queryKey: ["bitcoinBalance"],
+    queryKey: ["walletBalance"],
     queryFn: async () => {
       const program = Effect.flatMap(SparkService, (s) => s.getBalance());
       const exitResult = await Effect.runPromiseExit(
@@ -30,7 +30,8 @@ const BitcoinBalanceDisplay: React.FC = () => {
       }
       throw Cause.squash(exitResult.cause);
     },
-    refetchInterval: 30000, // Refetch every 30 seconds
+    // TODO: Aggressive 1s balance refresh. Monitor performance and API rate limits. Consider websockets or longer intervals for production.
+    refetchInterval: 1000,
     refetchIntervalInBackground: true,
   });
 

--- a/src/components/hud/BitcoinBalanceDisplay.tsx
+++ b/src/components/hud/BitcoinBalanceDisplay.tsx
@@ -1,6 +1,6 @@
 // src/components/hud/BitcoinBalanceDisplay.tsx
-import React from "react";
-import { useQuery } from "@tanstack/react-query";
+import React, { useEffect } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Effect, Exit, Cause } from "effect";
 import { SparkService, type BalanceInfo } from "@/services/spark";
 import { getMainRuntime } from "@/services/runtime";
@@ -11,8 +11,18 @@ import { Bitcoin, RefreshCw, AlertTriangle, Loader2 } from "lucide-react";
 
 const BitcoinBalanceDisplay: React.FC = () => {
   const runtime = getMainRuntime();
+  const queryClient = useQueryClient();
   const openWalletPane = usePaneStore((state) => state.openWalletPane);
+  const openWalletSetupPane = usePaneStore((state) => state.openWalletSetupPane);
   const walletIsInitialized = useWalletStore((state) => state.isInitialized);
+  
+  // Clear balance cache when wallet is not initialized
+  useEffect(() => {
+    if (!walletIsInitialized) {
+      queryClient.invalidateQueries({ queryKey: ["walletBalance"] });
+      queryClient.removeQueries({ queryKey: ["walletBalance"] });
+    }
+  }, [walletIsInitialized, queryClient]);
 
   const {
     data: balanceData,
@@ -39,7 +49,11 @@ const BitcoinBalanceDisplay: React.FC = () => {
   });
 
   const handleDisplayClick = () => {
-    openWalletPane();
+    if (walletIsInitialized) {
+      openWalletPane();
+    } else {
+      openWalletSetupPane();
+    }
   };
 
   let displayContent;

--- a/src/components/hud/BitcoinBalanceDisplay.tsx
+++ b/src/components/hud/BitcoinBalanceDisplay.tsx
@@ -5,12 +5,14 @@ import { Effect, Exit, Cause } from "effect";
 import { SparkService, type BalanceInfo } from "@/services/spark";
 import { getMainRuntime } from "@/services/runtime";
 import { usePaneStore } from "@/stores/pane";
+import { useWalletStore } from "@/stores/walletStore";
 import { Button } from "@/components/ui/button";
 import { Bitcoin, RefreshCw, AlertTriangle, Loader2 } from "lucide-react";
 
 const BitcoinBalanceDisplay: React.FC = () => {
   const runtime = getMainRuntime();
   const openWalletPane = usePaneStore((state) => state.openWalletPane);
+  const walletIsInitialized = useWalletStore((state) => state.isInitialized);
 
   const {
     data: balanceData,
@@ -33,6 +35,7 @@ const BitcoinBalanceDisplay: React.FC = () => {
     // TODO: Aggressive 1s balance refresh. Monitor performance and API rate limits. Consider websockets or longer intervals for production.
     refetchInterval: 1000,
     refetchIntervalInBackground: true,
+    enabled: walletIsInitialized, // Only fetch if wallet is initialized
   });
 
   const handleDisplayClick = () => {
@@ -40,7 +43,9 @@ const BitcoinBalanceDisplay: React.FC = () => {
   };
 
   let displayContent;
-  if (isLoading && !balanceData) {
+  if (!walletIsInitialized) {
+    displayContent = "No wallet";
+  } else if (isLoading && !balanceData) {
     displayContent = (
       <>
         <Loader2 className="mr-1 h-3 w-3 animate-spin" /> Loading...

--- a/src/components/wallet/WalletPane.tsx
+++ b/src/components/wallet/WalletPane.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useQuery, useMutation } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import QRCode from "react-qr-code";
 import { Effect, Exit, Cause } from "effect";
 import {
@@ -13,6 +13,7 @@ import {
 import { getMainRuntime } from "@/services/runtime";
 import { TelemetryService } from "@/services/telemetry";
 import { useWalletStore } from "@/stores/walletStore";
+import { usePaneStore } from "@/stores/pane";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -39,10 +40,19 @@ import LogoutWarningDialog from "./LogoutWarningDialog";
 
 const WalletPane: React.FC = () => {
   const runtime = getMainRuntime();
+  const queryClient = useQueryClient();
   const [activeTab, setActiveTab] = useState("balance");
 
   // Get wallet initialization status
   const walletIsInitialized = useWalletStore((state) => state.isInitialized);
+
+  // Clear balance cache when wallet is not initialized
+  useEffect(() => {
+    if (!walletIsInitialized) {
+      queryClient.invalidateQueries({ queryKey: ["walletBalance"] });
+      queryClient.removeQueries({ queryKey: ["walletBalance"] });
+    }
+  }, [walletIsInitialized, queryClient]);
 
   // --- Balance State ---
   const {
@@ -62,6 +72,7 @@ const WalletPane: React.FC = () => {
     },
     // TODO: Aggressive 1s balance refresh. Monitor performance and API rate limits. Consider websockets or longer intervals for production.
     refetchInterval: 1000,
+    enabled: walletIsInitialized, // Only fetch if wallet is initialized
   });
 
   // --- Lightning Invoice Generation State ---
@@ -274,18 +285,20 @@ const WalletPane: React.FC = () => {
           </CardTitle>
         </CardHeader>
         <CardContent className="flex-grow overflow-hidden p-1">
-          <div className="mb-2 flex items-center justify-center gap-2">
-            <ViewSeedPhraseDialog>
-              <Button variant="outline" size="sm" className="text-xs">
-                <Key className="mr-1.5 h-3 w-3" /> View Seed Phrase
-              </Button>
-            </ViewSeedPhraseDialog>
-            <LogoutWarningDialog>
-              <Button variant="outline" size="sm" className="text-xs">
-                <LogOut className="mr-1.5 h-3 w-3" /> Logout
-              </Button>
-            </LogoutWarningDialog>
-          </div>
+          {walletIsInitialized && (
+            <div className="mb-2 flex items-center justify-center gap-2">
+              <ViewSeedPhraseDialog>
+                <Button variant="outline" size="sm" className="text-xs">
+                  <Key className="mr-1.5 h-3 w-3" /> View Seed Phrase
+                </Button>
+              </ViewSeedPhraseDialog>
+              <LogoutWarningDialog>
+                <Button variant="outline" size="sm" className="text-xs">
+                  <LogOut className="mr-1.5 h-3 w-3" /> Logout
+                </Button>
+              </LogoutWarningDialog>
+            </div>
+          )}
 
           <Tabs
             value={activeTab}
@@ -296,10 +309,18 @@ const WalletPane: React.FC = () => {
               <TabsTrigger value="balance" className="h-6 text-xs">
                 Balance
               </TabsTrigger>
-              <TabsTrigger value="lightning" className="h-6 text-xs">
+              <TabsTrigger 
+                value="lightning" 
+                className="h-6 text-xs" 
+                disabled={!walletIsInitialized}
+              >
                 Lightning
               </TabsTrigger>
-              <TabsTrigger value="onchain" className="h-6 text-xs">
+              <TabsTrigger 
+                value="onchain" 
+                className="h-6 text-xs"
+                disabled={!walletIsInitialized}
+              >
                 On-Chain
               </TabsTrigger>
             </TabsList>
@@ -311,32 +332,53 @@ const WalletPane: React.FC = () => {
               <ScrollArea className="h-full">
                 <div className="space-y-4 p-3 text-center">
                   <h3 className="text-sm font-semibold">Current Balance</h3>
-                  {isLoadingBalance && (
+                  {!walletIsInitialized ? (
+                    <div className="text-muted-foreground">
+                      <p className="text-lg">No wallet</p>
+                      <p className="text-xs mt-1">Set up a wallet to view balance</p>
+                      <Button
+                        onClick={() => {
+                          const { openWalletSetupPane } = usePaneStore.getState();
+                          openWalletSetupPane();
+                        }}
+                        variant="outline"
+                        size="sm"
+                        className="mt-3"
+                      >
+                        Set Up Wallet
+                      </Button>
+                    </div>
+                  ) : isLoadingBalance && !balanceData ? (
                     <div className="text-muted-foreground">
                       <Loader2 className="mr-1 inline h-4 w-4 animate-spin" />
                       Loading...
                     </div>
-                  )}
-                  {balanceError && (
+                  ) : balanceError ? (
                     <div className="text-destructive">
                       <AlertTriangle className="mr-1 inline h-4 w-4" />
                       {balanceError.message}
                     </div>
-                  )}
-                  {balanceData && (
+                  ) : balanceData ? (
                     <p className="text-3xl font-bold text-yellow-400">
                       <span className="text-xl">₿</span>{" "}
                       {balanceData.balance.toString()}
                     </p>
+                  ) : (
+                    <div className="text-muted-foreground">
+                      <Loader2 className="mr-1 inline h-4 w-4 animate-spin" />
+                      Initializing...
+                    </div>
                   )}
-                  <Button
-                    onClick={() => refetchBalance()}
-                    variant="outline"
-                    size="sm"
-                    className="mx-auto mt-2 w-full max-w-xs"
-                  >
-                    <RefreshCw className="mr-1.5 h-3 w-3" /> Refresh Balance
-                  </Button>
+                  {walletIsInitialized && (
+                    <Button
+                      onClick={() => refetchBalance()}
+                      variant="outline"
+                      size="sm"
+                      className="mx-auto mt-2 w-full max-w-xs"
+                    >
+                      <RefreshCw className="mr-1.5 h-3 w-3" /> Refresh Balance
+                    </Button>
+                  )}
                 </div>
               </ScrollArea>
             </TabsContent>

--- a/src/components/wallet/WalletPane.tsx
+++ b/src/components/wallet/WalletPane.tsx
@@ -51,7 +51,7 @@ const WalletPane: React.FC = () => {
     error: balanceError,
     refetch: refetchBalance,
   } = useQuery<BalanceInfo, Error>({
-    queryKey: ["walletPaneBitcoinBalance"],
+    queryKey: ["walletBalance"],
     queryFn: async () => {
       const program = Effect.flatMap(SparkService, (s) => s.getBalance());
       const exitResult = await Effect.runPromiseExit(
@@ -60,7 +60,8 @@ const WalletPane: React.FC = () => {
       if (Exit.isSuccess(exitResult)) return exitResult.value;
       throw Cause.squash(exitResult.cause);
     },
-    refetchInterval: 60000,
+    // TODO: Aggressive 1s balance refresh. Monitor performance and API rate limits. Consider websockets or longer intervals for production.
+    refetchInterval: 1000,
   });
 
   // --- Lightning Invoice Generation State ---

--- a/src/stores/pane.ts
+++ b/src/stores/pane.ts
@@ -381,7 +381,7 @@ export const usePaneStore = create<PaneStoreType>()(
         }),
     }),
     {
-      name: "commander-pane-storage-v2",
+      name: "commander-pane-storage-v3", // v3: Reset to remove wallet setup panes
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         panes: state.panes,

--- a/src/stores/panes/actions/openWalletSetupPane.ts
+++ b/src/stores/panes/actions/openWalletSetupPane.ts
@@ -9,7 +9,7 @@ export function openWalletSetupPaneAction(set: SetPaneStore) {
       id: WALLET_SETUP_PANE_ID,
       type: "wallet_setup_content",
       title: WALLET_SETUP_PANE_TITLE,
-      dismissable: false, // Usually setup flows are not dismissable
+      dismissable: true, // Users should be able to dismiss and set up wallet later
       width: 500,
       height: 400,
     };

--- a/src/stores/walletStore.ts
+++ b/src/stores/walletStore.ts
@@ -181,7 +181,7 @@ export const useWalletStore = create<WalletState & WalletActions>()(
       },
     }),
     {
-      name: "commander-wallet-store",
+      name: "commander-wallet-store-v2", // v2: Reset to clear test wallet data
       storage: createJSONStorage(() => localStorage),
       partialize: (state) => ({
         // Only persist these fields


### PR DESCRIPTION
## Summary
This PR fixes multiple wallet-related UI issues:
- Synchronizes wallet balance between Wallet Pane and HUD
- Fixes logout behavior to clear balance display
- Removes automatic wallet setup on startup
- Fixes "No wallet" click to open setup screen

## Changes

### 1. Wallet Balance Synchronization
- Changed React Query key to `["walletBalance"]` in both WalletPane and BitcoinBalanceDisplay
- Set refresh interval to 1 second for real-time updates
- Both displays now share the same cache and update together

### 2. Logout Behavior
- BitcoinBalanceDisplay now checks `walletIsInitialized` state
- Shows "No wallet" when logged out instead of stale balance
- Disabled balance fetching when wallet not initialized

### 3. Removed Automatic Wallet Setup
- Disabled `checkWalletSetupNeeded()` in App.tsx
- Users must explicitly choose to set up wallet
- Changed pane storage key to v3 to clear persisted panes

### 4. Fixed "No wallet" Click Behavior
- Clicking "No wallet" now opens wallet setup screen
- Changed wallet store key to v2 to clear test wallet data
- Added React Query cache clearing on logout

## Testing
1. Refresh the page - only Sell Compute pane should appear
2. Click "No wallet" in top-right - wallet setup should open
3. Set up wallet and check balance syncs between pane and HUD
4. Logout and verify balance shows "No wallet"

## Breaking Changes
- Storage keys changed (pane v3, wallet v2) - all users will get fresh start
- Automatic wallet setup removed - users must manually initiate

🤖 Generated with Claude Code